### PR TITLE
fix: expose port for be and fe

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -63,12 +63,12 @@ services:
       file: ./services/sig-provider.yml
       service: sig-provider
 
-  # frontend:
-  #   depends_on:
-  #     - backend
-  #   extends:
-  #     file: ./services/frontend.yml
-  #     service: frontend
+  frontend:
+    depends_on:
+      - backend
+    extends:
+      file: ./services/frontend.yml
+      service: frontend
 
   stats-db-init:
     extends:
@@ -94,7 +94,7 @@ services:
   proxy:
     depends_on:
       - backend
-      # - frontend
+      - frontend
       - stats
       - sc-verifier
     extends:

--- a/docker-compose/services/backend.yml
+++ b/docker-compose/services/backend.yml
@@ -8,6 +8,9 @@ services:
     stop_grace_period: 5m
     container_name: 'backend'
     command: sh -c "bin/blockscout eval \"Elixir.Explorer.ReleaseTasks.create_and_migrate()\" && bin/blockscout start"
+    ports:
+      - target: 4000
+        published: 4000
     extra_hosts:
       - 'host.docker.internal:host-gateway'
     env_file:

--- a/docker-compose/services/frontend.yml
+++ b/docker-compose/services/frontend.yml
@@ -4,6 +4,9 @@ services:
   frontend:
     image: ghcr.io/blockscout/frontend:${FRONTEND_DOCKER_TAG:-latest}
     pull_policy: always
+    ports:
+      - target: 3000
+        published: 3000
     platform: linux/amd64
     restart: always
     container_name: 'frontend'


### PR DESCRIPTION
*[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)*

## Motivation

*Why we should merge these changes.  If using GitHub keywords to close [issues](https://github.com/poanetwork/blockscout/issues), this is optional as the motivation can be read on the issue page.*

## Changelog

### Enhancements
*Things you added that don't break anything.  Regression tests for Bug Fixes count as Enhancements.*

### Bug Fixes
*Things you changed that fix bugs.  If a fixes a bug, but in so doing adds a new requirement, removes code, or requires a database reset and reindex, the breaking part of the change should be added to Incompatible Changes below also.*

### Incompatible Changes
*Things you broke while doing Enhancements and Bug Fixes.  Breaking changes include (1) adding new requirements and (2) removing code.  Renaming counts as (2) because a rename is a removal followed by an add.*

## Upgrading

*If you have any Incompatible Changes in the above Changelog, outline how users of prior versions can upgrade once this PR lands or when reviewers are testing locally.  A common upgrading step is "Database reset and re-index required".*

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
